### PR TITLE
#13468 Display a combo dropdown with method and url

### DIFF
--- a/flowSteps/apiCallPandadoc/step.js
+++ b/flowSteps/apiCallPandadoc/step.js
@@ -22,32 +22,23 @@ step.apiCallPandadoc = function (inputs) {
     headers: inputs.headers || [],
     params: inputs.params || [],
     body: inputs.body || {},
-    callbackData: inputs.callbackData || "",
-    callbacks: inputs.callbacks || "",
-    followRedirects: inputs.followRedirects || false,
     download: inputs.download || false,
     fileName: inputs.fileName || "",
     fullResponse: inputs.fullResponse || false,
     connectionTimeout: inputs.connectionTimeout || 5000,
     readTimeout: inputs.readTimeout || 60000,
-    events: inputs.events || "",
     url: inputs.url || {
       urlValue: "",
-      paramsValue: [],
-      method: ""
+      paramsValue: []
     },
-    action: inputs.action || ""
+    method: inputs.method || ""
   };
+
 
   inputs.headers = isObject(inputs.headers) ? inputs.headers : stringToObject(inputs.headers);
   inputs.params = isObject(inputs.params) ? inputs.params : stringToObject(inputs.params);
   inputs.body = isObject(inputs.body) ? inputs.body : JSON.parse(inputs.body);
 
-  inputs.callbacks = inputs.callbacks ?
-    eval("inputs.callbacks = {" + inputs.events + " : function(event, callbackData) {" + inputs.callbacks + "}}") :
-    inputs.callbacks;
-
-  inputs.callbackData = inputs.callbackData ? {record: inputs.callbackData} : inputs.callbackData;
 
   var options = {
     path: parse(inputs.url.urlValue, inputs.url.paramsValue),
@@ -55,37 +46,34 @@ step.apiCallPandadoc = function (inputs) {
     headers: inputs.headers,
     body: inputs.body,
     followRedirects : inputs.followRedirects,
-    forceDownload : inputs.events === "fileDownloaded" ? true : inputs.download,
-    downloadSync : inputs.events === "fileDownloaded" ? false : inputs.download,
+    forceDownload :inputs.download,
+    downloadSync : false,
     fileName: inputs.fileName,
     fullResponse : inputs.fullResponse,
     connectionTimeout: inputs.connectionTimeout,
-    readTimeout: inputs.readTimeout,
-    defaultCallback: !!inputs.events
-  };
+    readTimeout: inputs.readTimeout
+  }
 
   switch (inputs.url.method.toLowerCase()) {
     case 'get':
-      return endpoint._get(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._get(options);
     case 'post':
-      return endpoint._post(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._post(options);
     case 'delete':
-      return endpoint._delete(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._delete(options);
     case 'put':
-      return endpoint._put(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._put(options);
     case 'connect':
-      return endpoint._connect(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._connect(options);
     case 'head':
-      return endpoint._head(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._head(options);
     case 'options':
-      return endpoint._options(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._options(options);
     case 'patch':
-      return endpoint._patch(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._patch(options);
     case 'trace':
-      return endpoint._trace(options, inputs.callbackData, inputs.callbacks);
+      return endpoint._trace(options);
   }
-
-  
 
   return null;
 };

--- a/flowSteps/apiCallPandadoc/step.js
+++ b/flowSteps/apiCallPandadoc/step.js
@@ -28,7 +28,7 @@ step.apiCallPandadoc = function (inputs) {
     connectionTimeout: inputs.connectionTimeout || 5000,
     readTimeout: inputs.readTimeout || 60000,
     url: inputs.url || {
-      urlValue: "",
+      urlValue: inputs.url.urlValue ? inputs.url.urlValue.split(" ")[1] : "",
       paramsValue: []
     },
     method: inputs.url.urlValue ? inputs.url.urlValue.split(" ")[0] : ""

--- a/flowSteps/apiCallPandadoc/step.js
+++ b/flowSteps/apiCallPandadoc/step.js
@@ -27,9 +27,9 @@ step.apiCallPandadoc = function (inputs) {
     fullResponse: inputs.fullResponse || false,
     connectionTimeout: inputs.connectionTimeout || 5000,
     readTimeout: inputs.readTimeout || 60000,
-    url: inputs.url || {
+    url: {
       urlValue: inputs.url.urlValue ? inputs.url.urlValue.split(" ")[1] : "",
-      paramsValue: []
+      paramsValue: inputs.url.paramsValue || []
     },
     method: inputs.url.urlValue ? inputs.url.urlValue.split(" ")[0] : ""
   };

--- a/flowSteps/apiCallPandadoc/step.js
+++ b/flowSteps/apiCallPandadoc/step.js
@@ -31,7 +31,7 @@ step.apiCallPandadoc = function (inputs) {
       urlValue: "",
       paramsValue: []
     },
-    method: inputs.method || ""
+    method: inputs.url.urlValue ? inputs.url.urlValue.split(" ")[0] : ""
   };
 
 
@@ -54,7 +54,7 @@ step.apiCallPandadoc = function (inputs) {
     readTimeout: inputs.readTimeout
   }
 
-  switch (inputs.url.method.toLowerCase()) {
+  switch (inputs.method.toLowerCase()) {
     case 'get':
       return endpoint._get(options);
     case 'post':

--- a/flowSteps/apiCallPandadoc/step.json
+++ b/flowSteps/apiCallPandadoc/step.json
@@ -68,7 +68,7 @@
       "type": "json",
       "description": "This is used to set body request",
       "options": {
-        "allowContextSelector": "false"
+        "allowContextSelector": "true"
       }
     },
     {

--- a/flowSteps/apiCallPandadoc/step.json
+++ b/flowSteps/apiCallPandadoc/step.json
@@ -12,42 +12,38 @@
       "required": "false",
       "options": {
         "type": "dropDown",
-        "possibleValues": {
-          "get": [
-            {
-              "label": "/documents"
-            },
-            {
-              "label": "/documents/{documentId}"
-            },
-            {
-              "label": "/documents/{documentId}/details"
-            },
-            {
-              "label": "/documents/{documentId}/download"
-            },
-            {
-              "label": "/templates"
-            },
-            {
-              "label": "/templates/{templateId}/details"
-            }
-          ],
-          "post": [
-            {
-              "label": "/documents"
-            },
-            {
-              "label": "/documents/{fileId}"
-            },
-            {
-              "label": "/documents/{documentId}/send"
-            },
-            {
-              "label": "/documents/{documentId}/session"
-            }
-          ]
-        }
+        "possibleValues": [
+          {
+            "label": "GET /documents"
+          },
+          {
+            "label": "GET /documents/{documentId}"
+          },
+          {
+            "label": "GET /documents/{documentId}/details"
+          },
+          {
+            "label": "GET /documents/{documentId}/download"
+          },
+          {
+            "label": "GET /templates"
+          },
+          {
+            "label": "GET /templates/{templateId}/details"
+          },
+          {
+            "label": "POST /documents"
+          },
+          {
+            "label": "POST /documents/{fileId}"
+          },
+          {
+            "label": "POST /documents/{documentId}/send"
+          },
+          {
+            "label": "POST /documents/{documentId}/session"
+          }
+        ]
       }
     },
     {

--- a/flowSteps/apiCallPandadoc/step.json
+++ b/flowSteps/apiCallPandadoc/step.json
@@ -9,7 +9,7 @@
       "name": "url",
       "description": "The method and path to which this endpoint will send the request.",
       "type": "urlParams",
-      "required": "false",
+      "required": "true",
       "options": {
         "type": "dropDown",
         "possibleValues": [

--- a/flowSteps/apiCallPandadoc/step.json
+++ b/flowSteps/apiCallPandadoc/step.json
@@ -72,48 +72,6 @@
       }
     },
     {
-      "label": "Event",
-      "name": "events",
-      "type": "dropDown",
-      "description": "Select event",
-      "multiplicity": "one",
-      "options": {
-        "possibleValues": [
-          {
-            "label": "File Downloaded",
-            "name": "fileDownloaded"
-          },
-          {
-            "label": "Callback",
-            "name": "callback"
-          }
-        ],
-        "allowContextSelector": "false"
-      }
-    },
-    {
-      "label": "Callback Data",
-      "name": "callbackData",
-      "type": "text",
-      "description": "This is an object you can send that you will get back when the function is processed",
-      "visibility": "config.events",
-      "options": {
-        "representation": "textArea",
-        "allowContextSelector": "true"
-      }
-    },
-    {
-      "label": "Callbacks",
-      "name": "callbacks",
-      "type": "script",
-      "description": "This is a map where you can listener for different function",
-      "visibility": "config.events",
-      "options": {
-        "allowContextSelector": "false",
-        "parameters": ["event","callbackData"]
-      }
-    },
-    {
       "label": "Override Settings",
       "name": "overrideSettings",
       "type": "boolean",

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <!-- SLINGR versions -->
-        <slingr.slingr-endpoints.version>2.0-SNAPSHOT</slingr.slingr-endpoints.version>
+        <slingr.slingr-endpoints.version>1.0-SNAPSHOT</slingr.slingr-endpoints.version>
         <!-- Core libraries properties -->
         <log4j.version>2.8.2</log4j.version>
         <logentries.version>1.1.11</logentries.version>


### PR DESCRIPTION
Pull-request for issue #13468 created by @agreggio-slingr

## What it does?

When selecting URL, display a combo dropdown with method and URL. For example:
GET /documents
GET /documents/{documentId}
POST /documents

## How to test it?

Config a new pandadoc-endpoint

Use pandadoc-endpoint and create an action with Action Type -> Flow

In the flow designer, create a new apiCall step and validate the dropdown contain verb + route, for example:
GET /download/{id}

Go to runtime and launch action

## Implementation notes

Need to create a new pandadoc tag

## Deployment notes

There are no deployment notes